### PR TITLE
[hooks] fail commit unless formatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # viaduct
+
+# Setup instructions
+
+After cloning the repository, run 
+
+```sh
+$ ./autohook.sh install
+```
+
+to set up the Git commit hooks we use to ensure code is formatted correctly.

--- a/hooks/autohook.sh
+++ b/hooks/autohook.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Autohook
+# A very, very small Git hook manager with focus on automation
+# Contributors:   https://github.com/Autohook/Autohook/graphs/contributors
+# Version:        2.3.0
+# Website:        https://github.com/Autohook/Autohook
+
+
+echo() {
+    builtin echo "[Autohook] $@";
+}
+
+
+install() {
+    hook_types=(
+        "applypatch-msg"
+        "commit-msg"
+        "post-applypatch"
+        "post-checkout"
+        "post-commit"
+        "post-merge"
+        "post-receive"
+        "post-rewrite"
+        "post-update"
+        "pre-applypatch"
+        "pre-auto-gc"
+        "pre-commit"
+        "pre-push"
+        "pre-rebase"
+        "pre-receive"
+        "prepare-commit-msg"
+        "update"
+    )
+
+    repo_root=$(git rev-parse --show-toplevel)
+    hooks_dir="$repo_root/.git/hooks"
+    autohook_linktarget="../../hooks/autohook.sh"
+    for hook_type in "${hook_types[@]}"
+    do
+        hook_symlink="$hooks_dir/$hook_type"
+        ln -sf $autohook_linktarget $hook_symlink
+    done
+}
+
+
+main() {
+    calling_file=$(basename $0)
+
+    if [[ $calling_file == "autohook.sh" ]]
+    then
+        command=$1
+        if [[ $command == "install" ]]
+        then
+            install
+        fi
+    else
+        repo_root=$(git rev-parse --show-toplevel)
+        hook_type=$calling_file
+        symlinks_dir="$repo_root/hooks/$hook_type"
+        files=("$symlinks_dir"/*)
+        number_of_symlinks="${#files[@]}"
+        if [[ $number_of_symlinks == 1 ]]
+        then
+            if [[ "$(basename ${files[0]})" == "*" ]]
+            then
+                number_of_symlinks=0
+            fi
+        fi
+        echo "Looking for $hook_type scripts to run...found $number_of_symlinks!"
+        if [[ $number_of_symlinks -gt 0 ]]
+        then
+            hook_exit_code=0
+            for file in "${files[@]}"
+            do
+                scriptname=$(basename $file)
+                echo "BEGIN $scriptname"
+                if [[ "${AUTOHOOK_DEBUG-}" == '' ]]; then
+                  eval "\"$file\"" &>/dev/null
+                else
+                  eval "\"$file\""
+                fi
+                script_exit_code="$?"
+                if [[ "$script_exit_code" != 0 ]]
+                then
+                  hook_exit_code=$script_exit_code
+                fi
+                echo "FINISH $scriptname"
+            done
+            if [[ $hook_exit_code != 0 ]]
+            then
+              echo "A $hook_type script yielded negative exit code $hook_exit_code"
+              exit $hook_exit_code
+            fi
+        fi
+    fi
+}
+
+
+main "$@"

--- a/hooks/pre-commit/01-ensure-formatted.sh
+++ b/hooks/pre-commit/01-ensure-formatted.sh
@@ -1,0 +1,1 @@
+../scripts/ensure-formatted.sh

--- a/hooks/scripts/ensure-formatted.sh
+++ b/hooks/scripts/ensure-formatted.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -euxo pipefail
+scripts/ormolu.sh -c && scripts/cabal-fmt.sh -c && exit 0


### PR DESCRIPTION
uses a pre-commit hook written using the tiny [autohook](https://github.com/Autohook/Autohook) script to run syntax checking scripts on the codebase and cause the commit to fail if it introduces code that is not formatted correctly. importantly, this does not modify any files.

a server-side hook would be ideal in order to _enforce_ this policy if required